### PR TITLE
Fix consecutive block-level constructs not parsed correctly

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -672,6 +672,7 @@ pub const Parser = struct {
         self.skipWhitespace();
         const then_body = try self.parseBracedNodes();
 
+        const pos_after_then = self.pos;
         self.skipWhitespace();
         const else_body: ?[]const ast.Node = if (self.match("else")) blk: {
             self.skipWhitespace();
@@ -682,7 +683,10 @@ pub const Parser = struct {
                 break :blk nodes;
             }
             break :blk try self.parseBracedNodes();
-        } else null;
+        } else blk: {
+            self.pos = pos_after_then;
+            break :blk null;
+        };
 
         return .{ .condition = condition, .then_body = then_body, .else_body = else_body, .loc = loc };
     }

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -82,6 +82,74 @@ def test_block_else_if(zt):
     assert result == '<span>two</span>'
 
 
+def test_consecutive_if_and_for(zt):
+    """Two block-level constructs in sequence (issue #1)."""
+    result = zt.run(
+        '''pub templ run(items: []const []const u8) {
+            if (items.len == 0) {
+                <p>No items</p>
+            }
+            for (items) |item| {
+                <article>
+                    <header>{item}</header>
+                </article>
+            }
+        }''',
+        args='.{&[_][]const u8{"a", "b"}}',
+    )
+    assert result == '<article><header>a</header></article><article><header>b</header></article>'
+
+
+def test_consecutive_if_and_for_empty(zt):
+    """Two block-level constructs in sequence, empty case (issue #1)."""
+    result = zt.run(
+        '''pub templ run(items: []const []const u8) {
+            if (items.len == 0) {
+                <p>No items</p>
+            }
+            for (items) |item| {
+                <article>
+                    <header>{item}</header>
+                </article>
+            }
+        }''',
+        args='.{&[_][]const u8{}}',
+    )
+    assert result == '<p>No items</p>'
+
+
+def test_consecutive_ifs(zt):
+    """Two consecutive if blocks (issue #1)."""
+    result = zt.run(
+        '''pub templ run(a: bool, b: bool) {
+            if (a) {
+                <p>A</p>
+            }
+            if (b) {
+                <p>B</p>
+            }
+        }''',
+        args='.{true, true}',
+    )
+    assert result == '<p>A</p><p>B</p>'
+
+
+def test_consecutive_fors(zt):
+    """Two consecutive for blocks (issue #1)."""
+    result = zt.run(
+        '''pub templ run(a: []const []const u8, b: []const []const u8) {
+            for (a) |x| {
+                <p>{x}</p>
+            }
+            for (b) |y| {
+                <span>{y}</span>
+            }
+        }''',
+        args='.{&[_][]const u8{"a", "b"}, &[_][]const u8{"c", "d"}}',
+    )
+    assert result == '<p>a</p><p>b</p><span>c</span><span>d</span>'
+
+
 def test_block_for(zt):
     result = zt.run(
         '''pub templ run(items: []const []const u8) {


### PR DESCRIPTION
## Summary
- After parsing an if-statement's then-body, `skipWhitespace()` consumed newlines while looking ahead for an `else` clause. When no `else` was found, the consumed newline was lost, causing the parent `parseNodes` loop to miss the next block-level construct and treat it as plain text.
- Save parser position before the lookahead and restore it when no `else` clause is found.
- Added tests for consecutive if+for, consecutive ifs, and consecutive fors.

Fixes #1