### PR TITLE
Add support for if with optional captures

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -69,8 +69,10 @@ pub const Expr = struct {
 };
 
 /// Inline if: {if (cond) <span>yes</span> else <span>no</span>}
+/// With capture: {if (opt) |val| <span>{val}</span>}
 pub const IfExpr = struct {
     condition: []const u8,
+    capture: ?[]const u8 = null,
     then_branch: Branch,
     else_branch: ?Branch,
 };
@@ -99,8 +101,10 @@ pub const ComponentCall = struct {
 };
 
 /// Block-level: if (cond) { ... } else { ... }
+/// With capture: if (opt) |val| { ... }
 pub const IfStatement = struct {
     condition: []const u8,
+    capture: ?[]const u8 = null,
     then_body: []const Node,
     else_body: ?[]const Node,
     loc: Location = .{},

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -419,7 +419,13 @@ pub const Generator = struct {
         try self.writeIndent();
         try self.output.writeAll("if (");
         try self.output.writeAll(if_expr.condition);
-        try self.output.writeAll(") {\n");
+        try self.output.writeAll(")");
+        if (if_expr.capture) |cap| {
+            try self.output.writeAll(" |");
+            try self.output.writeAll(cap);
+            try self.output.writeAll("|");
+        }
+        try self.output.writeAll(" {\n");
 
         self.indent += 1;
         try self.generateBranch(if_expr.then_branch, raw);
@@ -494,7 +500,13 @@ pub const Generator = struct {
         try self.writeIndent();
         try self.output.writeAll("if (");
         try self.output.writeAll(stmt.condition);
-        try self.output.writeAll(") {\n");
+        try self.output.writeAll(")");
+        if (stmt.capture) |cap| {
+            try self.output.writeAll(" |");
+            try self.output.writeAll(cap);
+            try self.output.writeAll("|");
+        }
+        try self.output.writeAll(" {\n");
 
         self.indent += 1;
         for (stmt.then_body) |node| {
@@ -527,7 +539,13 @@ pub const Generator = struct {
     fn generateIfStmtInline(self: *Generator, stmt: ast.IfStatement) std.Io.Writer.Error!void {
         try self.output.writeAll("if (");
         try self.output.writeAll(stmt.condition);
-        try self.output.writeAll(") {\n");
+        try self.output.writeAll(")");
+        if (stmt.capture) |cap| {
+            try self.output.writeAll(" |");
+            try self.output.writeAll(cap);
+            try self.output.writeAll("|");
+        }
+        try self.output.writeAll(" {\n");
 
         self.indent += 1;
         for (stmt.then_body) |node| {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -542,6 +542,14 @@ pub const Parser = struct {
         self.skipSpaces();
         const condition = try self.parseParenExpr();
         self.skipSpaces();
+
+        // Optional capture: |val|
+        const capture: ?[]const u8 = if (self.peek() == @as(u8, '|'))
+            try self.parseCaptures()
+        else
+            null;
+
+        self.skipSpaces();
         const then_branch = try self.parseBranch();
         self.skipSpaces();
         const else_branch: ?ast.Branch = if (self.match("else")) blk: {
@@ -549,7 +557,7 @@ pub const Parser = struct {
             break :blk try self.parseBranch();
         } else null;
 
-        return .{ .condition = condition, .then_branch = then_branch, .else_branch = else_branch };
+        return .{ .condition = condition, .capture = capture, .then_branch = then_branch, .else_branch = else_branch };
     }
 
     fn parseBranch(self: *Parser) Error!ast.Branch {
@@ -673,6 +681,14 @@ pub const Parser = struct {
         self.skipSpaces();
 
         const condition = try self.parseParenExpr();
+        self.skipSpaces();
+
+        // Optional capture: |val|
+        const capture: ?[]const u8 = if (self.peek() == @as(u8, '|'))
+            try self.parseCaptures()
+        else
+            null;
+
         self.skipWhitespace();
         const then_body = try self.parseBracedNodes();
 
@@ -692,7 +708,7 @@ pub const Parser = struct {
             break :blk null;
         };
 
-        return .{ .condition = condition, .then_body = then_body, .else_body = else_body, .loc = loc };
+        return .{ .condition = condition, .capture = capture, .then_body = then_body, .else_body = else_body, .loc = loc };
     }
 
     // =========================================================================
@@ -1042,9 +1058,12 @@ test "parse inline if with zig code branches" {
     const if_expr = template.body[0].expr.content.if_expr;
     try std.testing.expectEqualStrings("value", if_expr.condition);
 
-    // Then branch is zig code
+    // Capture is parsed
+    try std.testing.expectEqualStrings("v", if_expr.capture.?);
+
+    // Then branch is zig code (the captured variable)
     try std.testing.expect(if_expr.then_branch == .zig_code);
-    try std.testing.expectEqualStrings("|v| v", if_expr.then_branch.zig_code);
+    try std.testing.expectEqualStrings("v", if_expr.then_branch.zig_code);
 
     // Else branch is zig code
     try std.testing.expect(if_expr.else_branch.? == .zig_code);

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -32,6 +32,51 @@ def test_inline_if_zig_expr(zt):
     assert result == 'yes'
 
 
+def test_inline_if_capture(zt):
+    """Inline if with optional capture."""
+    result = zt.run(
+        'pub templ run(x: ?[]const u8) { {if (x) |val| <b>{val}</b>} }',
+        args='.{"hi"}',
+    )
+    assert result == '<b>hi</b>'
+
+
+def test_inline_if_capture_null(zt):
+    """Inline if with optional capture, null case."""
+    result = zt.run(
+        'pub templ run(x: ?[]const u8) { {if (x) |val| <b>{val}</b>} }',
+        args='.{null}',
+    )
+    assert result == ''
+
+
+def test_inline_if_capture_else(zt):
+    """Inline if with optional capture and else."""
+    result = zt.run(
+        'pub templ run(x: ?[]const u8) { {if (x) |val| <b>{val}</b> else <i>none</i>} }',
+        args='.{"test"}',
+    )
+    assert result == '<b>test</b>'
+
+
+def test_inline_if_capture_else_null(zt):
+    """Inline if with optional capture and else, null case."""
+    result = zt.run(
+        'pub templ run(x: ?[]const u8) { {if (x) |val| <b>{val}</b> else <i>none</i>} }',
+        args='.{null}',
+    )
+    assert result == '<i>none</i>'
+
+
+def test_inline_if_capture_zig_expr(zt):
+    """Inline if with optional capture returning Zig expression."""
+    result = zt.run(
+        'pub templ run(x: ?[]const u8) { {if (x) |val| val else "default"} }',
+        args='.{"value"}',
+    )
+    assert result == 'value'
+
+
 def test_inline_for(zt):
     result = zt.run(
         'pub templ run(items: []const []const u8) { {for (items) |x| <i>{x}</i>} }',
@@ -80,6 +125,62 @@ def test_block_else_if(zt):
         args='.{2}',
     )
     assert result == '<span>two</span>'
+
+
+def test_block_if_capture(zt):
+    """Block-level if with optional capture."""
+    result = zt.run(
+        '''pub templ run(x: ?[]const u8) {
+            if (x) |val| {
+                <span>{val}</span>
+            }
+        }''',
+        args='.{"hello"}',
+    )
+    assert result == '<span>hello</span>'
+
+
+def test_block_if_capture_null(zt):
+    """Block-level if with optional capture, null case."""
+    result = zt.run(
+        '''pub templ run(x: ?[]const u8) {
+            if (x) |val| {
+                <span>{val}</span>
+            }
+        }''',
+        args='.{null}',
+    )
+    assert result == ''
+
+
+def test_block_if_capture_else(zt):
+    """Block-level if with optional capture and else branch."""
+    result = zt.run(
+        '''pub templ run(x: ?[]const u8) {
+            if (x) |val| {
+                <span>{val}</span>
+            } else {
+                <span>none</span>
+            }
+        }''',
+        args='.{"world"}',
+    )
+    assert result == '<span>world</span>'
+
+
+def test_block_if_capture_else_null(zt):
+    """Block-level if with optional capture and else branch, null case."""
+    result = zt.run(
+        '''pub templ run(x: ?[]const u8) {
+            if (x) |val| {
+                <span>{val}</span>
+            } else {
+                <span>none</span>
+            }
+        }''',
+        args='.{null}',
+    )
+    assert result == '<span>none</span>'
 
 
 def test_consecutive_if_and_for(zt):


### PR DESCRIPTION
## Summary
- Support Zig's optional unwrapping syntax: `if (opt) |val| { ... }`
- Works in both block-level and inline if statements
- Add `capture` field to `IfExpr` and `IfStatement` AST nodes

## Test plan
- [x] Added 9 new integration tests covering:
  - Inline if with capture (value present and null)
  - Inline if with capture and else branch
  - Inline if with capture returning Zig expression
  - Block-level if with capture (value present and null)
  - Block-level if with capture and else branch
- [x] All 76 integration tests pass
- [x] All 52 Zig unit tests pass