### PR TITLE
Add support for <!DOCTYPE> declarations

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -27,6 +27,7 @@ pub const Node = union(enum) {
     for_stmt: ForStatement,
     switch_stmt: SwitchStatement,
     component_call: ComponentCall,
+    doctype: Doctype,
 };
 
 pub const Element = struct {
@@ -51,6 +52,10 @@ pub const Attribute = struct {
 
 pub const Text = struct {
     content: []const u8,
+};
+
+pub const Doctype = struct {
+    value: []const u8,
 };
 
 /// Expression block: { ... } or raw: {! ... }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -272,6 +272,7 @@ pub const Generator = struct {
             .for_stmt => |stmt| try self.generateForStmt(stmt),
             .switch_stmt => |stmt| try self.generateSwitchStmt(stmt),
             .component_call => |call| try self.generateComponentCall(call),
+            .doctype => |doctype| try self.generateDoctype(doctype),
         }
     }
 
@@ -393,6 +394,13 @@ pub const Generator = struct {
         try self.output.writeAll("try writer.writeAll(\"");
         try self.writeEscapedForZig(text.content);
         try self.output.writeAll("\");\n");
+    }
+
+    fn generateDoctype(self: *Generator, doctype: ast.Doctype) std.Io.Writer.Error!void {
+        try self.writeIndent();
+        try self.output.writeAll("try writer.writeAll(\"<!DOCTYPE ");
+        try self.output.writeAll(doctype.value);
+        try self.output.writeAll(">\");\n");
     }
 
     fn generateExpr(self: *Generator, expr: ast.Expr) std.Io.Writer.Error!void {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -338,9 +338,12 @@ pub const Parser = struct {
 
         if (c == '<') {
             if (self.check("</")) return null;
-            if (self.check("<!")) {
+            if (self.check("<!--")) {
                 try self.skipComment();
                 return self.parseNode(allow_block_constructs);
+            }
+            if (self.checkDoctypeInsensitive()) {
+                return .{ .doctype = try self.parseDoctype() };
             }
             return .{ .element = try self.parseElement() };
         }
@@ -978,13 +981,36 @@ pub const Parser = struct {
                 if (self.advance() == null) return self.fail("unexpected end of file in comment", .{});
             }
             _ = self.match("-->");
-        } else if (self.match("<!")) {
-            // DOCTYPE or similar
-            while (self.peek() != @as(u8, '>')) {
-                if (self.advance() == null) return self.fail("unexpected end of file in doctype", .{});
-            }
+        }
+    }
+
+    fn checkDoctypeInsensitive(self: *Parser) bool {
+        const prefix = "<!DOCTYPE";
+        if (self.pos + prefix.len > self.source.len) return false;
+        const slice = self.source[self.pos .. self.pos + prefix.len];
+        return std.ascii.eqlIgnoreCase(slice, prefix);
+    }
+
+    fn parseDoctype(self: *Parser) Error!ast.Doctype {
+        // Skip "<!DOCTYPE" (case insensitive)
+        self.pos += 9;
+        self.col += 9;
+
+        self.skipSpaces();
+
+        // Parse the doctype value (e.g., "html")
+        const start = self.pos;
+        while (self.peek()) |ch| {
+            if (ch == '>' or std.ascii.isWhitespace(ch)) break;
             _ = self.advance();
         }
+        const value = self.source[start..self.pos];
+
+        self.skipSpaces();
+
+        if (!self.match(">")) return self.fail("expected '>' to close DOCTYPE", .{});
+
+        return .{ .value = value };
     }
 };
 
@@ -1742,4 +1768,43 @@ test "parse escaped vs raw" {
 
     const raw = template.body[1].expr;
     try std.testing.expect(raw.raw);
+}
+
+test "parse doctype" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const source =
+        \\templ test() {
+        \\    <!DOCTYPE html>
+        \\    <html></html>
+        \\}
+    ;
+
+    var parser = Parser.init(arena.allocator(), source);
+    const template = try parser.parseTemplate();
+
+    try std.testing.expectEqual(@as(usize, 2), template.body.len);
+    try std.testing.expect(template.body[0] == .doctype);
+    try std.testing.expectEqualStrings("html", template.body[0].doctype.value);
+    try std.testing.expect(template.body[1] == .element);
+}
+
+test "parse doctype case insensitive" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const source =
+        \\templ test() {
+        \\    <!doctype html>
+        \\    <html></html>
+        \\}
+    ;
+
+    var parser = Parser.init(arena.allocator(), source);
+    const template = try parser.parseTemplate();
+
+    try std.testing.expectEqual(@as(usize, 2), template.body.len);
+    try std.testing.expect(template.body[0] == .doctype);
+    try std.testing.expectEqualStrings("html", template.body[0].doctype.value);
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -311,3 +311,18 @@ def test_expr_with_trailing_text(zt):
         args='.{"Ramen"}',
     )
     assert result == '<header>Ramen | test</header>'
+
+
+def test_doctype(zt):
+    """Regression test for https://github.com/lalinsky/zt/issues/8"""
+    result = zt.run('pub templ run() { <!DOCTYPE html><html></html> }')
+    assert result == '<!DOCTYPE html><html></html>'
+
+
+def test_doctype_with_whitespace(zt):
+    """DOCTYPE followed by content with whitespace"""
+    result = zt.run('''pub templ run() {
+    <!DOCTYPE html>
+    <html lang="en"></html>
+}''')
+    assert result == '<!DOCTYPE html><html lang="en"></html>'


### PR DESCRIPTION
## Summary

- Add `Doctype` node type to AST
- Parse `<!DOCTYPE ...>` (case insensitive) as a doctype node instead of skipping it
- Generate proper DOCTYPE output in codegen
- Add integration and unit tests

Fixes #8