### PR TITLE
Fix void-returning functions printing 'void' in output

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -106,6 +106,9 @@ pub fn writeEscaped(writer: *std.Io.Writer, value: anytype) std.Io.Writer.Error!
         .bool => {
             try writer.writeAll(if (value) "true" else "false");
         },
+        .void => {
+            // Do nothing for void return values
+        },
         else => {
             try writeFormatted(writer, value);
         },
@@ -164,10 +167,13 @@ pub fn writeRaw(writer: *std.Io.Writer, value: anytype) std.Io.Writer.Error!void
                 return;
             }
         },
-        else => {},
+        .void => {
+            // Do nothing for void return values
+        },
+        else => {
+            try writer.print("{}", .{value});
+        },
     }
-
-    try writer.print("{}", .{value});
 }
 
 // =========================================================================

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -407,3 +407,17 @@ pub templ run(recipe: Recipe) {
 }
 ''', args='.{.{ .title = "Ramen" }}')
     assert result == '<header>Ramen\n        | test\n    </header>'
+
+
+def test_void_function_no_output(zt):
+    """Test that void-returning functions don't print 'void' - issue #11"""
+    result = zt.run('''
+fn writeDate(writer: *@import("std").Io.Writer) void {
+    writer.writeAll("2022-05-06") catch return;
+}
+
+pub templ run() {
+    <p>Created {!writeDate(writer)}</p>
+}
+''')
+    assert result == '<p>Created 2022-05-06</p>'


### PR DESCRIPTION
## Summary
- Fixes #11
- When a function returning `void` was used in a template expression like `{!writeDate(writer)}`, the literal string "void" would be printed after the function's output
- Added `.void` case to `writeEscaped` and `writeRaw` in runtime.zig that does nothing, allowing functions to write directly to the writer without their return value being printed

## Test plan
- Added integration test `test_void_function_no_output` that verifies a void-returning function that writes to the writer doesn't produce "void" in output
- All existing tests pass