### PR TITLE
Remove debug print that caused stderr output in build

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -64,5 +64,4 @@ fn compileTemplate(allocator: std.mem.Allocator, input_path: []const u8, output_
         std.debug.print("Error writing '{s}': {}\n", .{ output_path, err });
         return error.WriteFailed;
     };
-    std.debug.print("Wrote {s}\n", .{output_path});
 }


### PR DESCRIPTION
## Summary
- Remove the "Wrote ..." debug print message that was causing the Zig build system to display "stderr" in the build tree
- This message was printed via `std.debug.print` which writes to stderr, making successful builds look like they had errors

Fixes #13