### PR TITLE
Fix inline switch with block branches containing HTML

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -97,11 +97,12 @@ pub const ForExpr = struct {
     body: Branch,
 };
 
-/// Branch in inline if/for - element, component call, nested if, or zig code
+/// Branch in inline if/for - element, component call, nested if, nodes block, or zig code
 pub const Branch = union(enum) {
     element: *Element,
     component_call: ComponentCall,
     if_expr: *IfExpr,
+    nodes: []const Node,
     zig_code: []const u8,
 };
 

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -502,6 +502,11 @@ pub const Generator = struct {
             .element => |elem| try self.generateElement(elem.*),
             .component_call => |call| try self.generateComponentCall(call),
             .if_expr => |if_expr| try self.generateIfExpr(if_expr.*, raw),
+            .nodes => |nodes| {
+                for (nodes) |node| {
+                    try self.generateNode(node);
+                }
+            },
             .zig_code => |code| {
                 try self.writeIndent();
                 if (raw) {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -619,11 +619,11 @@ pub const Parser = struct {
         // Check for raw output: {!expr}
         const is_raw = self.match("!");
 
-        self.skipSpaces();
+        self.skipWhitespace();
 
         const content = try self.parseExprContent();
 
-        self.skipSpaces();
+        self.skipWhitespace();
         if (!self.match("}")) return self.fail("expected '}}' to close expression", .{});
 
         return .{ .content = content, .raw = is_raw, .loc = loc };
@@ -718,6 +718,11 @@ pub const Parser = struct {
 
     fn parseSwitchBranchBody(self: *Parser) Error!ast.Branch {
         const c = self.peek() orelse return self.fail("unexpected end of file in branch", .{});
+
+        // Block with template nodes: { ... }
+        if (c == '{') {
+            return .{ .nodes = try self.parseBracedNodes() };
+        }
 
         // Element branch: <tag>...</tag>
         if (c == '<' and !self.check("</")) {
@@ -933,22 +938,22 @@ pub const Parser = struct {
 
     fn parseSwitchExpr(self: *Parser) Error!ast.SwitchExpr {
         _ = self.match("switch");
-        self.skipSpaces();
+        self.skipWhitespace();
         const value = try self.parseParenExpr();
-        self.skipSpaces();
+        self.skipWhitespace();
 
         if (!self.match("{")) return self.fail("expected '{{' after switch expression", .{});
 
         var cases: std.ArrayList(ast.SwitchBranch) = .empty;
         while (true) {
-            self.skipSpaces();
+            self.skipWhitespace();
             if (self.peek() == @as(u8, '}')) break;
             try cases.append(self.allocator, try self.parseSwitchBranch());
-            self.skipSpaces();
+            self.skipWhitespace();
             if (!self.match(",")) break;
         }
 
-        self.skipSpaces();
+        self.skipWhitespace();
         if (!self.match("}")) return self.fail("expected '}}' to close switch", .{});
 
         return .{ .value = value, .cases = cases.items };
@@ -956,16 +961,16 @@ pub const Parser = struct {
 
     fn parseSwitchBranch(self: *Parser) Error!ast.SwitchBranch {
         const pattern = try self.parseSwitchPattern();
-        self.skipSpaces();
+        self.skipWhitespace();
         if (!self.match("=>")) return self.fail("expected '=>' after switch pattern", .{});
-        self.skipSpaces();
+        self.skipWhitespace();
 
         const capture: ?[]const u8 = if (self.peek() == @as(u8, '|'))
             try self.parseCaptures()
         else
             null;
 
-        self.skipSpaces();
+        self.skipWhitespace();
         return .{ .pattern = pattern, .capture = capture, .body = try self.parseSwitchBranchBody() };
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,10 @@ pub fn main() !void {{
             env=env,
         )
         if result.returncode != 0:
-            raise RuntimeError(f"zig build run failed:\n{result.stderr}")
+            generated = ""
+            if zig_file.exists():
+                generated = f"\n\nGenerated code:\n{zig_file.read_text()}"
+            raise RuntimeError(f"zig build run failed:\n{result.stderr}{generated}")
 
         return result.stdout
 

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -557,3 +557,112 @@ def test_inline_switch_func_call(zt):
         args='.{.active}',
     )
     assert result == '42'
+
+
+def test_text_then_switch_then_text(zt):
+    """Regression test for https://github.com/lalinsky/zt/issues/17
+
+    Text followed by switch statement should not consume the switch keyword as text.
+    """
+    result = zt.run(
+        '''const Visibility = enum { private, public };
+
+        pub templ run(v: Visibility) {
+            <h1>
+                test text
+                {
+                    switch (v) {
+                        .private => {
+                            <img src="/static/img/lock.svg" />
+                        },
+                        .public => {
+                            <img src="/static/img/public.svg" />
+                        },
+                    }
+                }
+                more text
+            </h1>
+        }''',
+        args='.{.private}',
+    )
+    assert '<h1>' in result
+    assert 'test text' in result
+    assert '<img src="/static/img/lock.svg">' in result
+    assert 'more text' in result
+    assert '</h1>' in result
+    # Make sure switch is NOT treated as text
+    assert 'switch' not in result
+
+
+def test_inline_switch_with_block_branches(zt):
+    """Inline switch with { } blocks containing HTML in branches, sandwiched by text on separate lines."""
+    result = zt.run(
+        '''const Visibility = enum { private, public };
+
+        pub templ run(v: Visibility) {
+            <h1>
+                before
+                {switch (v) { .private => { <img src="/lock.svg" /> }, .public => { <img src="/public.svg" /> } }}
+                after
+            </h1>
+        }''',
+        args='.{.public}',
+    )
+    assert 'before' in result
+    assert '<img src="/public.svg">' in result
+    assert 'after' in result
+    assert 'switch' not in result
+
+
+def test_issue17_comment_case1(zt):
+    """Test case from issue #17 comment - multiline with newline after {"""
+    result = zt.run(
+        '''const Visibility = enum { private, public };
+
+        pub templ run(v: Visibility) {
+            <h1>
+                test text
+
+                {
+                    switch (v) {
+                        .private => {
+                            <img src="/static/img/lock.svg" />
+                        },
+                        .public => {
+                            <img src="/static/img/public.svg" />
+                        },
+                    }
+                }
+            </h1>
+        }''',
+        args='.{.private}',
+    )
+    assert 'test text' in result
+    assert '<img src="/static/img/lock.svg">' in result
+    assert 'switch' not in result
+
+
+def test_issue17_comment_case2(zt):
+    """Test case from issue #17 comment - space after { with multiline switch"""
+    result = zt.run(
+        '''const Visibility = enum { private, public };
+
+        pub templ run(v: Visibility) {
+            <h1>
+                test text
+
+                { switch (v) {
+                    .private => {
+                        <img src="/static/img/lock.svg" />
+                    },
+                    .public => {
+                        <img src="/static/img/public.svg" />
+                    },
+                } }
+            </h1>
+        }''',
+        args='.{.public}',
+    )
+    assert 'test text' in result
+    assert '<img src="/static/img/public.svg">' in result
+    assert 'switch' not in result


### PR DESCRIPTION
## Summary

- Support `{ switch (v) { .case => { <html/> }, ... } }` syntax where switch branches use `{ }` blocks containing template content
- Add `nodes` variant to `Branch` union for template blocks in inline constructs
- Use `skipWhitespace` instead of `skipSpaces` in expression/switch parsing to support multiline syntax

## Test plan

- [x] Added regression test for multiline switch with text before/after
- [x] Added test for inline switch with block branches
- [x] All 104 integration tests pass
- [x] All 55 Zig unit tests pass

Fixes #17