### PR TITLE
Fix inline if/for with block branches containing HTML

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -662,9 +662,9 @@ pub const Parser = struct {
 
     fn parseIfExpr(self: *Parser) Error!ast.IfExpr {
         _ = self.match("if");
-        self.skipSpaces();
+        self.skipWhitespace();
         const condition = try self.parseParenExpr();
-        self.skipSpaces();
+        self.skipWhitespace();
 
         // Optional capture: |val|
         const capture: ?[]const u8 = if (self.peek() == @as(u8, '|'))
@@ -672,17 +672,17 @@ pub const Parser = struct {
         else
             null;
 
-        self.skipSpaces();
+        self.skipWhitespace();
         const then_branch = try self.parseBranch();
-        self.skipSpaces();
+        self.skipWhitespace();
 
         var else_capture: ?[]const u8 = null;
         const else_branch: ?ast.Branch = if (self.match("else")) blk: {
-            self.skipSpaces();
+            self.skipWhitespace();
             // Optional else capture: else |err|
             if (self.peek() == @as(u8, '|')) {
                 else_capture = try self.parseCaptures();
-                self.skipSpaces();
+                self.skipWhitespace();
             }
             break :blk try self.parseBranch();
         } else null;
@@ -692,6 +692,11 @@ pub const Parser = struct {
 
     fn parseBranch(self: *Parser) Error!ast.Branch {
         const c = self.peek() orelse return self.fail("unexpected end of file in branch", .{});
+
+        // Block with template nodes: { ... }
+        if (c == '{') {
+            return .{ .nodes = try self.parseBracedNodes() };
+        }
 
         // Element branch: <tag>...</tag>
         if (c == '<' and !self.check("</")) {
@@ -796,11 +801,11 @@ pub const Parser = struct {
 
     fn parseForExpr(self: *Parser) Error!ast.ForExpr {
         _ = self.match("for");
-        self.skipSpaces();
+        self.skipWhitespace();
         const iterable = try self.parseParenExpr();
-        self.skipSpaces();
+        self.skipWhitespace();
         const captures = try self.parseCaptures();
-        self.skipSpaces();
+        self.skipWhitespace();
         const body = try self.parseBranch();
 
         return .{ .iterable = iterable, .captures = captures, .body = body };

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -666,3 +666,46 @@ def test_issue17_comment_case2(zt):
     assert 'test text' in result
     assert '<img src="/static/img/public.svg">' in result
     assert 'switch' not in result
+
+
+def test_issue17_comment_if_block(zt):
+    """Test case from issue #17 comment - if with block containing HTML after text"""
+    result = zt.run(
+        '''pub templ run(number_of_portions: ?u32) {
+            <h2>
+                test text
+
+                {
+                    if (number_of_portions) |n| {
+                        <p>Portions: {n}</p>
+                    }
+                }
+            </h2>
+        }''',
+        args='.{4}',
+    )
+    assert 'test text' in result
+    assert '<p>Portions: 4</p>' in result
+    assert 'if' not in result
+
+
+def test_issue17_comment_for_block(zt):
+    """Test for loop with block containing HTML after text"""
+    result = zt.run(
+        '''pub templ run(items: []const []const u8) {
+            <ul>
+                header text
+
+                {
+                    for (items) |item| {
+                        <li>{item}</li>
+                    }
+                }
+            </ul>
+        }''',
+        args='.{&.{"apple", "banana"}}',
+    )
+    assert 'header text' in result
+    assert '<li>apple</li>' in result
+    assert '<li>banana</li>' in result
+    assert 'for' not in result


### PR DESCRIPTION
## Summary

- Apply the same fix from switch branches (#18) to if and for expressions
- Support `{ if (cond) { <html/> } }` and `{ for (items) |i| { <html/> } }` syntax
- Use `skipWhitespace` instead of `skipSpaces` for multiline support

## Test plan

- [x] Added `test_issue17_comment_if_block` test
- [x] Added `test_issue17_comment_for_block` test
- [x] All 108 tests pass
- [x] `check.sh` passes

Fixes #17