### PR TITLE
Port to Zig 0.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: 0.15.0
+        version: 0.16.0
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0xc36136a62c712ca1, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zt_example,
     .version = "0.0.0",
     .fingerprint = 0xd0284a75840f835b,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zt = .{
             .path = "..",

--- a/examples/src/main.zig
+++ b/examples/src/main.zig
@@ -3,9 +3,9 @@ const templates = @import("templates/hello.zig");
 const User = @import("models.zig").User;
 const Post = @import("models.zig").Post;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var buf: [8192]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
+    var stdout = std.Io.File.stdout().writer(init.io, &buf);
     const w = &stdout.interface;
 
     const user = User{

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,11 +52,27 @@ fn compileTemplate(allocator: std.mem.Allocator, io: std.Io, input_path: []const
         return error.GenerateFailed;
     };
 
-    const generated = output.writer.buffer[0..output.writer.end];
+    const raw = output.writer.buffer[0..output.writer.end];
+
+    // Run the result through zig's own formatter so the file we write is
+    // `zig fmt` clean. On a parse error we write the unformatted source
+    // anyway: the compiler's diagnostics on the real file beat anything we
+    // could say here, and the file has to exist for it to point at.
+    const generated = formatZig(alloc, raw) catch |err| blk: {
+        std.debug.print("{s}: warning: generated code did not format ({}), writing as-is\n", .{ output_path, err });
+        break :blk raw;
+    };
 
     // Write output
     std.Io.Dir.cwd().writeFile(io, .{ .sub_path = output_path, .data = generated }) catch |err| {
         std.debug.print("Error writing '{s}': {}\n", .{ output_path, err });
         return error.WriteFailed;
     };
+}
+
+fn formatZig(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
+    const source_z = try allocator.dupeZ(u8, source);
+    var tree = try std.zig.Ast.parse(allocator, source_z, .zig);
+    if (tree.errors.len > 0) return error.InvalidZig;
+    return tree.renderAlloc(allocator);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const zt = @import("zt.zig");
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.arena.allocator();
-
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 3 or args.len % 2 != 1) {
@@ -13,7 +11,7 @@ pub fn main(init: std.process.Init) !void {
 
     var i: usize = 1;
     while (i < args.len) : (i += 2) {
-        try compileTemplate(allocator, init.io, args[i], args[i + 1]);
+        try compileTemplate(init.gpa, init.io, args[i], args[i + 1]);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
 const zt = @import("zt.zig");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 3 or args.len % 2 != 1) {
         std.debug.print("Usage: zt-compile <input.zt> <output.zig> ...\n", .{});
@@ -16,17 +13,17 @@ pub fn main() !void {
 
     var i: usize = 1;
     while (i < args.len) : (i += 2) {
-        try compileTemplate(allocator, args[i], args[i + 1]);
+        try compileTemplate(allocator, init.io, args[i], args[i + 1]);
     }
 }
 
-fn compileTemplate(allocator: std.mem.Allocator, input_path: []const u8, output_path: []const u8) !void {
+fn compileTemplate(allocator: std.mem.Allocator, io: std.Io, input_path: []const u8, output_path: []const u8) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
 
     // Read source
-    const source = std.fs.cwd().readFileAlloc(alloc, input_path, 10 * 1024 * 1024) catch |err| {
+    const source = std.Io.Dir.cwd().readFileAlloc(io, input_path, alloc, .limited(10 * 1024 * 1024)) catch |err| {
         std.debug.print("Error reading '{s}': {}\n", .{ input_path, err });
         return error.ReadFailed;
     };
@@ -60,7 +57,7 @@ fn compileTemplate(allocator: std.mem.Allocator, input_path: []const u8, output_
     const generated = output.writer.buffer[0..output.writer.end];
 
     // Write output
-    std.fs.cwd().writeFile(.{ .sub_path = output_path, .data = generated }) catch |err| {
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = output_path, .data = generated }) catch |err| {
         std.debug.print("Error writing '{s}': {}\n", .{ output_path, err });
         return error.WriteFailed;
     };

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -14,14 +14,18 @@ pub const std_options = std.Options{
 const std = @import("std");
 const builtin = @import("builtin");
 
+const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
 const BORDER = "=" ** 80;
 
-// Log capture for suppressing logs in passing tests
+// Log capture for suppressing logs in passing tests.
+// The Io is stashed at startup so the global log callback can perform mutex
+// operations without having to thread `Io` through every call site.
 const LogCapture = struct {
     capture_writer: ?*std.Io.Writer = null,
-    mutex: std.Thread.Mutex = .{},
+    mutex: Io.Mutex = .init,
+    io: ?Io = null,
 
     pub fn logFn(
         self: *@This(),
@@ -30,8 +34,14 @@ const LogCapture = struct {
         comptime format: []const u8,
         args: anytype,
     ) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = self.io orelse {
+            // No Io available yet — fall back to raw stderr.
+            const scope_prefix = "(" ++ @tagName(scope) ++ "/" ++ @tagName(level) ++ "): ";
+            std.debug.print(scope_prefix ++ format ++ "\n", args);
+            return;
+        };
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         const scope_prefix = "(" ++ @tagName(scope) ++ "/" ++ @tagName(level) ++ "): ";
 
@@ -39,20 +49,20 @@ const LogCapture = struct {
             // Write to capture buffer
             writer.print(scope_prefix ++ format ++ "\n", args) catch return;
         } else {
-            // Write to stderr (no locking needed, std.debug.print handles it)
+            // Write to stderr (std.debug.print handles its own locking)
             std.debug.print(scope_prefix ++ format ++ "\n", args);
         }
     }
 
-    pub fn startCapture(self: *@This(), writer: *std.Io.Writer) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn startCapture(self: *@This(), io: Io, writer: *std.Io.Writer) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.capture_writer = writer;
     }
 
-    pub fn stopCapture(self: *@This()) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn stopCapture(self: *@This(), io: Io) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.capture_writer = null;
     }
 };
@@ -71,28 +81,29 @@ pub fn customLogFn(
 // use in custom panic handler
 var current_test: ?[]const u8 = null;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
 
-    const allocator = gpa.allocator();
+    log_capture.io = io;
+    defer log_capture.io = null;
 
-    var env = Env.init(allocator);
-    defer env.deinit(allocator);
+    var env = Env.init(gpa, init.environ_map);
+    defer env.deinit(gpa);
 
-    var slowest = SlowTracker.init(allocator, 5);
-    defer slowest.deinit();
+    var slowest = SlowTracker.init(io, 5);
+    defer slowest.deinit(gpa);
 
     var pass: usize = 0;
     var fail: usize = 0;
     var skip: usize = 0;
     var leak: usize = 0;
 
-    var log_buffer: std.Io.Writer.Allocating = .init(allocator);
+    var log_buffer: std.Io.Writer.Allocating = .init(gpa);
     defer log_buffer.deinit();
 
     var failed_tests: std.ArrayList([]const u8) = .empty;
-    defer failed_tests.deinit(allocator);
+    defer failed_tests.deinit(gpa);
 
     Printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
 
@@ -127,7 +138,7 @@ pub fn main() !void {
         break :blk count;
     };
 
-    const root_node = if (!env.verbose) std.Progress.start(.{
+    const root_node = if (env.verbose == .off) std.Progress.start(io, .{
         .root_name = "Running tests",
         .estimated_total_items = test_count,
     }) else std.Progress.Node.none;
@@ -140,7 +151,7 @@ pub fn main() !void {
         }
 
         var status = Status.pass;
-        slowest.startTiming();
+        slowest.startTiming(io);
 
         const is_unnamed_test = isUnnamed(t);
         if (env.filters.items.len > 0) {
@@ -176,27 +187,31 @@ pub fn main() !void {
 
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
+        std.testing.io_instance = .init(gpa, .{});
 
         if (env.do_log_capture) {
             log_buffer.clearRetainingCapacity();
-            log_capture.startCapture(&log_buffer.writer);
+            log_capture.startCapture(io, &log_buffer.writer);
         }
 
         // Print test name before running (for debugging hangs)
-        if (env.verbose) {
-            Printer.fmt("{s} .. ", .{friendly_name});
+        switch (env.verbose) {
+            .naming => Printer.fmt("{s} .. ", .{friendly_name}),
+            .tracing => Printer.fmt("{s}\n", .{friendly_name}),
+            .off => {},
         }
 
         const result = t.func();
 
         if (env.do_log_capture) {
-            log_capture.stopCapture();
+            log_capture.stopCapture(io);
         }
 
         current_test = null;
 
-        const ns_taken = slowest.endTiming(friendly_name);
+        const ns_taken = slowest.endTiming(io, gpa, friendly_name);
 
+        std.testing.io_instance.deinit();
         if (std.testing.allocator_instance.deinit() == .leak) {
             leak += 1;
             Printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });
@@ -214,7 +229,7 @@ pub fn main() !void {
                 status = .fail;
                 fail += 1;
                 fail_err = err;
-                failed_tests.append(allocator, friendly_name) catch {};
+                failed_tests.append(gpa, friendly_name) catch {};
             },
         }
 
@@ -225,9 +240,17 @@ pub fn main() !void {
             .skip => "SKIP",
             .text => "",
         };
-        if (env.verbose) {
-            Printer.status(status, "{s}", .{status_str});
-            Printer.fmt(" ({d:.2}ms)\n", .{ms});
+        switch (env.verbose) {
+            .naming => {
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .tracing => {
+                Printer.fmt("  ", .{});
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .off => {},
         }
 
         // Print error details for failures (in non-verbose mode, progress will show above this)
@@ -242,11 +265,7 @@ pub fn main() !void {
 
             Printer.fmt("{s}\n", .{BORDER});
             if (@errorReturnTrace()) |trace| {
-                if (builtin.zig_version.major == 0 and builtin.zig_version.minor < 16) {
-                    std.debug.dumpStackTrace(trace.*);
-                } else {
-                    std.debug.dumpStackTrace(trace);
-                }
+                std.debug.dumpErrorReturnTrace(trace);
             }
             if (env.fail_first) {
                 break;
@@ -287,7 +306,7 @@ pub fn main() !void {
     Printer.fmt("\n", .{});
     try slowest.display();
     Printer.fmt("\n", .{});
-    std.posix.exit(if (fail == 0) 0 else 1);
+    std.process.exit(if (fail == 0) 0 else 1);
 }
 
 const Printer = struct {
@@ -317,16 +336,13 @@ const SlowTracker = struct {
     const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
     max: usize,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    started: Io.Clock.Timestamp,
 
-    fn init(allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slowest = SlowestQueue.init(allocator, {});
-        slowest.ensureTotalCapacity(count) catch @panic("OOM");
+    fn init(io: Io, count: u32) SlowTracker {
         return .{
             .max = count,
-            .timer = timer,
-            .slowest = slowest,
+            .started = .now(io, .awake),
+            .slowest = SlowestQueue.initContext({}),
         };
     }
 
@@ -335,24 +351,24 @@ const SlowTracker = struct {
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+    fn deinit(self: *SlowTracker, allocator: Allocator) void {
+        self.slowest.deinit(allocator);
     }
 
-    fn startTiming(self: *SlowTracker) void {
-        self.timer.reset();
+    fn startTiming(self: *SlowTracker, io: Io) void {
+        self.started = .now(io, .awake);
     }
 
-    fn endTiming(self: *SlowTracker, test_name: []const u8) u64 {
-        var timer = self.timer;
-        const ns = timer.lap();
+    fn endTiming(self: *SlowTracker, io: Io, allocator: Allocator, test_name: []const u8) u64 {
+        const now = Io.Clock.Timestamp.now(io, .awake);
+        const ns: u64 = @intCast(self.started.durationTo(now).raw.nanoseconds);
 
         var slowest = &self.slowest;
 
         if (slowest.count() < self.max) {
             // Capacity is fixed to the # of slow tests we want to track
             // If we've tracked fewer tests than this capacity, than always add
-            slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slowest.push(allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -367,8 +383,8 @@ const SlowTracker = struct {
         }
 
         // the previous fastest of our slow tests, has been pushed off.
-        _ = slowest.removeMin();
-        slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slowest.popMin();
+        slowest.push(allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
@@ -376,7 +392,7 @@ const SlowTracker = struct {
         var slowest = self.slowest;
         const count = slowest.count();
         Printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slowest.removeMinOrNull()) |info| {
+        while (slowest.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
             Printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
@@ -389,17 +405,17 @@ const SlowTracker = struct {
 };
 
 const Env = struct {
-    verbose: bool,
+    const Verbose = enum { off, naming, tracing };
+
+    verbose: Verbose,
     fail_first: bool,
     filters: std.ArrayList([]const u8),
     do_log_capture: bool,
 
-    fn init(allocator: Allocator) Env {
+    fn init(allocator: Allocator, environ_map: *std.process.Environ.Map) Env {
         var filters: std.ArrayList([]const u8) = .empty;
 
-        if (readEnv(allocator, "TEST_FILTER")) |filter_str| {
-            defer allocator.free(filter_str);
-
+        if (environ_map.get("TEST_FILTER")) |filter_str| {
             var iter = std.mem.splitScalar(u8, filter_str, '|');
             while (iter.next()) |part| {
                 const trimmed = std.mem.trim(u8, part, " \t");
@@ -411,10 +427,10 @@ const Env = struct {
         }
 
         return .{
-            .verbose = readEnvBool(allocator, "TEST_VERBOSE", false),
-            .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
+            .verbose = readEnvVerbose(environ_map),
+            .fail_first = readEnvBool(environ_map, "TEST_FAIL_FIRST", false),
             .filters = filters,
-            .do_log_capture = readEnvBool(allocator, "TEST_LOG_CAPTURE", true),
+            .do_log_capture = readEnvBool(environ_map, "TEST_LOG_CAPTURE", true),
         };
     }
 
@@ -425,21 +441,16 @@ const Env = struct {
         self.filters.deinit(allocator);
     }
 
-    fn readEnv(allocator: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(allocator, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
-            }
-            std.log.warn("failed to get env var {s} due to err {}", .{ key, err });
-            return null;
-        };
-        return v;
+    fn readEnvBool(environ_map: *std.process.Environ.Map, key: []const u8, deflt: bool) bool {
+        const value = environ_map.get(key) orelse return deflt;
+        return std.ascii.eqlIgnoreCase(value, "true");
     }
 
-    fn readEnvBool(allocator: Allocator, key: []const u8, deflt: bool) bool {
-        const value = readEnv(allocator, key) orelse return deflt;
-        defer allocator.free(value);
-        return std.ascii.eqlIgnoreCase(value, "true");
+    fn readEnvVerbose(environ_map: *std.process.Environ.Map) Verbose {
+        const value = environ_map.get("TEST_VERBOSE") orelse return .off;
+        if (std.ascii.eqlIgnoreCase(value, "2")) return .tracing;
+        if (std.ascii.eqlIgnoreCase(value, "true") or std.ascii.eqlIgnoreCase(value, "1")) return .naming;
+        return .off;
     }
 };
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,9 +153,9 @@ class ZtRunner:
 const std = @import("std");
 const tpl = @import("tpl.zig");
 
-pub fn main() !void {{
+pub fn main(init: std.process.Init) !void {{
     var buf: [8192]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
+    var stdout = std.Io.File.stdout().writer(init.io, &buf);
     const w = &stdout.interface;
     try tpl.run.render({args}, w);
     try w.flush();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,21 @@ pub fn main(init: std.process.Init) !void {{
                 generated = f"\n\nGenerated code:\n{zig_file.read_text()}"
             raise RuntimeError(f"zig build run failed:\n{result.stderr}{generated}")
 
+        # Generated code must be `zig fmt` clean. A dependent checks its own
+        # tree with `zig fmt --check`, and these files land in it.
+        fmt = subprocess.run(
+            ["zig", "fmt", "--check", str(zig_file)],
+            capture_output=True,
+            text=True,
+            cwd=self.workdir,
+            env=env,
+        )
+        if fmt.returncode != 0:
+            raise AssertionError(
+                f"generated code is not `zig fmt` clean for template:\n{template}\n\n"
+                f"Generated code:\n{zig_file.read_text()}"
+            )
+
         return result.stdout
 
 


### PR DESCRIPTION
Ports zt to Zig 0.16.

The first commit is @KOHCTAHT's, taken from their fork's `0.16.0` branch
unchanged. It converts `src/main.zig` and is correct as far as it goes, but it
was the only file touched, so `zig build test`, the example and the whole pytest
suite still did not compile. (There is a second fork, rfmineguy/zt, carrying a
byte-identical change plus some commented-out leftovers. Nothing extra to take
from it.)

## What the follow-up commit does

**`test_runner.zig`** is replaced with the one from `lalinsky/zio`, which is
already on 0.16. This is not a rename job: `std.Thread.Mutex` is gone and
`std.Io.Mutex.lock` wants an `Io` that the global log callback has no way to get,
so zio's version stashes the `Io` at startup instead of threading it through
every call site. Taking it wholesale also brings the rest of zio's drift:
`Io.Clock.Timestamp` timing instead of `std.time.Timer`, `std.testing.io_instance`,
the `PriorityDequeue` push/pop API, and `TEST_VERBOSE` widened from a bool to
`off`/`naming`/`tracing`. `TEST_VERBOSE=true` still means what it did, so
`check.sh` and CI are unaffected.

**`examples/src/main.zig`** and **`tests/conftest.py`** get the same one-line fix:
`std.fs.File.stdout()` is now `std.Io.File.stdout()`, and its writer takes an
`Io`. This matches what std's own benchmarks do.

**Version pins**: `minimum_zig_version` to 0.16.0 in both `.zon` files, and CI
from 0.15.0 to 0.16.0. CI was still on 0.15 and would have failed on the ported
`src/main.zig` either way, so this branch has never been green until now.

**`src/main.zig`**: the per-template arena is parented on `init.gpa` rather than
on the process arena. As written it was an arena on an arena, so `arena.deinit()`
handed memory back to something that cannot reuse it and peak memory grew with
the number of templates on one command line. `init.gpa` also restores the Debug
leak checking the old GPA gave.

## Second commit: `zig fmt` clean output

Separable, drop it if you would rather it went on its own.

Generated files land in the dependent's source tree via `addCopyFileToSource`, so
a project running `zig fmt --check .` fails on code it did not write. Two cases
today: codegen emits `.{"Home", x}` where fmt wants `.{ "Home", x }`, and a
trailing blank line. Rather than patch the emit sites, the generated source now
goes through `std.zig.Ast` before being written, which makes it clean by
construction and tracks whatever the toolchain's rules become. On a parse error
the unformatted source is written anyway with a warning, so the compiler's
diagnostics still land on the real file.

Note this is pre-existing, not from the port: 0.15's fmt flags the same file. CI
never saw it because the generated file is gitignored and does not exist yet when
`zig fmt --check .` runs on a clean checkout.

## Tests

Zig 0.16.0, Linux x86_64.

- `./check.sh --ci` passes (fmt check, unit tests, example build).
- `zig build test` -- 55 of 55.
- `python3 -m pytest tests/` -- 108 passed. The harness now also asserts every
  generated file is `zig fmt --check` clean, which is the regression test for the
  second commit: reverting the formatter fails the first test it reaches.
- `npx tree-sitter test` -- 52/52 parses.
- `cd examples && zig build run` renders the page.

`check.sh --ci --full` needs `python` on PATH; this box only has `python3`, so I
ran the pytest and tree-sitter stages directly. CI's `setup-python` provides
`python`, so that is local-only.

## What this does not cover

- **#22**: `build.zig` builds `zt-compile` for the dependent's target, so
  cross-compiling a dependent fails outright with `unable to spawn foreign
  binary`. Pre-existing and unrelated to the port. I had a fix and backed it out
  to keep this reviewable.
- `examples/output.txt` is tracked but stale, from an older set of templates, and
  nothing reads it any more. Left alone.
- `addTemplates` resolves the dependency with no optimize mode, so dependents
  always run a Debug `zt-compile`. Left alone.
